### PR TITLE
Update TorBox and ElfHosted Infinite Streaming Plex_Debrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 - [Premiumize](https://www.premiumize.me/) - cheapest plan `€9.99/mo` longest plan `€69.99/yr` limited to `1TB` download
 - [put.io](https://put.io/) - cheapest plan `$9.99/mo` longest plan `$99/yr` `10/50/100` Active Torrents limited to `100GB/1TB/10TB` download
 - [Real-Debrid](https://real-debrid.com/) - cheapest plan `€3/15d` longest plan `€16/180d` `42` Active Torrents `2TB` Per Torrent
+- [TorBox](https://torbox.app/) - cheapest plan `$3/mo` longest plan `$33/yr` `3/5/10` Active Torrents `200GB/500GB` Per Torrent
 
 <details>
   <summary>Not yet verified</summary>
@@ -54,7 +55,6 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 </details>
 
 ### Supports Torrent Only
-- [TorBox](https://torbox.app/) - cheapest plan `$3/mo` longest plan `$33/yr` `3/5/10` Active Torrents `100GB/500GB` Per Torrent
 - [PikPak](https://mypikpak.com/) - cheapest plan `$6.3/mo` longest plan `$63.99/yr` limited to `10TB` download
 
 ### Supports One-Click Hosters Only
@@ -77,7 +77,7 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 
 ### Hosting Providers (VPS, Seedbox..)
 
-* [ElfHosted](https://elfhosted.com) - Plex+Zurg+plex_debrid ["Infinite Streaming"](https://store.elfhosted.com/product/infinite-real-debrid-plex-streaming-bundle) for `$0.30/day or $9/month`
+* [ElfHosted](https://elfhosted.com) - Plex+Zurg+plex_debrid ["Infinite Streaming"](https://store.elfhosted.com/product/infinite-real-debrid-plex-streaming-bundle) for `$0.90/day or $19/month`
 
 ## *Arr Stack
 - [iceberg](https://github.com/dreulavelle/iceberg) - an up and coming plex_debrid rewrite


### PR DESCRIPTION
Elfhosted has tripled their prices, and TorBox has added one click hosters and doubled torrent size for the cheaper two plans.

There may be other things needing update, but these are the ones I have knowledge of.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced TorBox, a new debrid service with various pricing plans tailored to different service levels.
- **Documentation**
	- Updated pricing details for ElfHosted's "Infinite Streaming" bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->