### PR TITLE
Real-debrid isn't used for the seas anymore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 - [Offcloud](https://offcloud.com/) - cheapest plan `$9.99/mo` longest plan `$54.99/yr` lifetime plan (limited to 50 GB cloud storage for non cached links) `$39.99` from affiliate lifetime plan `$299.99` from Offcloud
 - [Premiumize](https://www.premiumize.me/) - cheapest plan `€9.99/mo` longest plan `€69.99/yr` limited to `1TB` download
 - [put.io](https://put.io/) - cheapest plan `$9.99/mo` longest plan `$99/yr` `10/50/100` Active Torrents limited to `100GB/1TB/10TB` download
-- [Real-Debrid](https://real-debrid.com/) - cheapest plan `€3/15d` longest plan `€16/180d` `42` Active Torrents `2TB` Per Torrent
 
 <details>
   <summary>Not yet verified</summary>
@@ -108,7 +107,6 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 
 ## Communities
 - [Debrid Media Manager & zurg subreddit](https://www.reddit.com/r/debridmediamanager/)
-- [Real-Debrid subreddit](https://www.reddit.com/r/RealDebrid/)
 - [plex_debrid Discord](https://discord.gg/gDvqjjD3)
 - [ElfHosted Discord](https://discord.elfhosted.com)
 


### PR DESCRIPTION
Real-debrid isnt very useful anymore :(
https://fixupx.com/RealDebrid/status/1859673163681960169
![{BF66CA15-7303-44E1-81FE-E6170400DE14}](https://github.com/user-attachments/assets/7f95384a-4aba-456f-83f9-18b539e258c8)
Everyone is moving to places like alldebrid or torbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded the description of Debrid services, highlighting new functionalities and security features.
	- Updated the list of Debrid services, removing Real-Debrid from relevant sections.
	- Enhanced the "Communities" section by removing outdated links and providing clearer descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->