### PR TITLE
Add Debrify to Content Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
 
 ## Content Managers
 - [Debrid Media Manager](https://debridmediamanager.com/)
+- [Debrify](https://github.com/varunsalian/debrify) - Cross-platform debrid manager for Real-Debrid, Torbox, and PikPak. Stream and download on Android & Android TV.
 - [Real Debrid Manager](https://rdm.ayush.gg/)
 - [Unchained](https://github.com/LivingWithHippos/unchained-android)
 


### PR DESCRIPTION
 ## Addition

  Adding Debrify to the Content Managers section.

  ## About Debrify

  - **Website:** https://varunsalian.github.io/debrify/
  - **GitHub:** https://github.com/varunsalian/debrify
  - **Platforms:** Android, Android TV
  - **Supported Services:** Real-Debrid, Torbox, PikPak

  Debrify is an open-source cross-platform debrid manager that lets users stream and download content from debrid services without torrenting on their device. Features include:

  - Built-in video player with streaming support
  - Download manager
  - Native Android TV support with D-pad navigation
  - Multi-service support (Real-Debrid, Torbox, PikPak)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Debrify to the list of Content Managers—a cross-platform debrid manager for Real-Debrid, Torbox, and PikPak with Android & Android TV support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->