### PR TITLE
Add Storage Portal to one-click hosters

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Downloading via a HTTPS link with a Debrid service provides enhanced security, a
   - ~~[Simply Debrid](https://simply-debrid.com/)~~ - pivoted to generic video downloader, no longer a debrid service
   - [Simply-Premium](https://simply-premium.com) - from `€5.83/mo`, 7-13 hosts + Usenet. Since 2009.
   - ~~[SMOOZED](https://www.smoozed.biz/)~~ - flagged as scam on GitHub/Tarnkappe.info
+  - [Storage Portal](https://www.storage-portal.com) - free 1GB, `$1/7GB`, `$45/600GB`. No monthly payment required; permanent traffic.
   - ~~[Superloading](https://superloading.com)~~ - 24 hosts. ⚠️ Dead.
   - [Vecwire](https://get.vecwire.com) - free (5/day) + premium, 12 hosts
 </details>


### PR DESCRIPTION
Adds Storage Portal to the Supports One-Click Hosters Only list with its free tier and pay-as-you-go traffic pricing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Storage Portal to the list of supported one-click hosters with pricing and traffic/payment details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debridmediamanager/awesome-debrid/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->