### PR TITLE
Add Torrin

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ PikPak is Xunlei reskinned for overseas markets. The Chinese "offline download" 
 ### Self-Hosted Cloud Torrent
 Deploy on any VPS to run your own cloud torrent service. Free (open source) — only pay for hosting.
 
+- [Torrin](https://github.com/torrin-app/torrin) - Go — open-source self-hosted debrid service. Add a magnet, get a stream. Stremio addon, web player, Docker image.
 - [TorrServer](https://github.com/YouROK/TorrServer) - Go — instant torrent streaming server. DLNA support. Cross-platform. Very popular.
 - [Simple Torrent](https://github.com/boypt/simple-torrent) - Go — self-hosted remote torrent client. Mobile-friendly web UI. RSS. Available on Umbrel/YunoHost.
 - [cloud-torrent](https://github.com/jpillora/cloud-torrent) - Go — remote torrent client with web UI. Deploy via Zeabur one-click. Docker Hub.


### PR DESCRIPTION
Adds [Torrin](https://github.com/torrin-app/torrin) to the Self-Hosted Cloud Torrent section.

Open-source, self-hosted debrid service with Stremio addon, web player, and Docker image.

- Website: https://torrin.app
- Docker: `ghcr.io/torrin-app/torrin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Torrin to the self-hosted cloud torrent options, featuring magnet-to-stream conversion, Stremio addon integration, web player, and Docker deployment support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debridmediamanager/awesome-debrid/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->